### PR TITLE
Title and description validation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,7 @@ group :test do
   gem 'database_cleaner'
   gem 'factory_girl_rails', '~> 4.0'
   gem 'shoulda-matchers', '~> 3.1'
+  gem 'rails-controller-testing'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -101,6 +101,10 @@ GEM
       bundler (>= 1.3.0, < 2.0)
       railties (= 5.1.2)
       sprockets-rails (>= 2.0.0)
+    rails-controller-testing (1.0.2)
+      actionpack (~> 5.x, >= 5.0.1)
+      actionview (~> 5.x, >= 5.0.1)
+      activesupport (~> 5.x)
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
@@ -172,6 +176,7 @@ DEPENDENCIES
   puma (~> 3.7)
   rack-cors
   rails (~> 5.1.2)
+  rails-controller-testing
   rspec-rails (~> 3.5)
   shoulda-matchers (~> 3.1)
   spring

--- a/app/controllers/talks_controller.rb
+++ b/app/controllers/talks_controller.rb
@@ -12,11 +12,12 @@ class TalksController < ApplicationController
   end
 
   def create
-    talk = Talk.create(talk_params) 
-    if talk.save
-      render json: talk, status: :created 
+    @talk = Talk.create(talk_params)
+
+    if @talk.save
+      render json: @talk, status: :created
     else
-      render json: { "error": "failed to create" }
+      render json: { "error": "failed to create: #{@talk.errors.full_messages.join(', ')}" }
     end
   end
 

--- a/app/models/concerns/description_length_validator.rb
+++ b/app/models/concerns/description_length_validator.rb
@@ -1,0 +1,10 @@
+class DescriptionLengthValidator < ActiveModel::Validator
+  def validate(record)
+    description = record.description
+    description_words = description.split(' ')
+
+    if description_words.size > 200
+      record.errors.add(:description, "has too many words")
+    end
+  end
+end

--- a/app/models/concerns/title_length_validator.rb
+++ b/app/models/concerns/title_length_validator.rb
@@ -1,0 +1,10 @@
+class TitleLengthValidator < ActiveModel::Validator
+  def validate(record)
+    title = record.title
+    title_words = title.split(' ')
+
+    if title_words.size > 10
+      record.errors.add(:title, "has too many words")
+    end
+  end
+end

--- a/app/models/talk.rb
+++ b/app/models/talk.rb
@@ -1,3 +1,5 @@
 class Talk < ApplicationRecord
   validates_presence_of :title, :category, :description
+  validates_with TitleLengthValidator
+  validates_with DescriptionLengthValidator
 end

--- a/app/models/talk.rb
+++ b/app/models/talk.rb
@@ -1,5 +1,13 @@
 class Talk < ApplicationRecord
   validates_presence_of :title, :category, :description
-  validates_with TitleLengthValidator
-  validates_with DescriptionLengthValidator
+  validates_with TitleLengthValidator, if: :title_present?
+  validates_with DescriptionLengthValidator, if: :description_present?
+
+  def title_present?
+    title.present?
+  end
+
+  def description_present?
+    description.present?
+  end
 end

--- a/spec/controllers/talks_controller_spec.rb
+++ b/spec/controllers/talks_controller_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+
+describe TalksController do
+
+  it "should post with valid parameters" do
+    talk = Talk.new(title: "title", category: "category", description: "description")
+    post :create, {params: talk.attributes}
+    expect(Talk.last.title).to eq(talk.title)
+  end
+
+  it "should not post with invalid parameters" do
+    title = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi id lacus ac sem suscipit dapibus accumsan ac lorem"
+    description = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi id lacus ac sem suscipit dapibus accumsan ac lorem. Curabitur sollicitudin auctor velit, quis ultrices mi ornare id. Aliquam ac scelerisque dolor. Nullam nec pharetra lectus. Sed porta dolor ac suscipit ultricies. Fusce vulputate libero ac suscipit varius. Vivamus lorem mauris, maximus sed cursus eget, posuere non arcu. Proin ultrices, mi sit amet luctus mollis, nulla dui maximus mi, vitae elementum dolor urna at mauris. Duis sed mattis nibh. Cras mattis volutpat dictum. Duis nisi nisi, semper eu sem et, vehicula commodo leo. Mauris vulputate ligula viverra, semper mi at, elementum leo. Aliquam finibus lorem quam, et accumsan tellus faucibus eu. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Morbi faucibus risus placerat, rutrum libero in, aliquam diam. Nam eu nisl non nisi mattis accumsan. Curabitur sodales tellus quam. Donec cursus imperdiet ipsum, ac egestas sem. Integer lacus quam, venenatis eu pulvinar ac, vestibulum consectetur neque. Mauris aliquam ultricies dignissim. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec sed elit sed velit accumsan sodales et id purus. Proin sed quam a enim varius sodales. Maecenas vel lectus sem. Duis eu nulla faucibus, molestie justo vitae, laoreet nisi. Duis commodo eget odio."
+    talk = Talk.new(title: title, category: "category", description: description)
+    post :create, {params: talk.attributes}
+    expect(assigns(:talk).errors.full_messages).to eq(["Title has too many words", "Description has too many words"])
+  end
+end

--- a/spec/controllers/talks_controller_spec.rb
+++ b/spec/controllers/talks_controller_spec.rb
@@ -16,4 +16,20 @@ describe TalksController do
     post :create, {params: talk.attributes}
     expect(assigns(:talk).errors.full_messages).to eq(["Title has too many words", "Description has too many words"])
   end
+
+  it "should not post with invalid title" do
+    title = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi id lacus ac sem suscipit dapibus accumsan ac lorem"
+    description = "this is a description"
+    talk = Talk.new(title: title, category: "category", description: description)
+    post :create, {params: talk.attributes}
+    expect(assigns(:talk).errors.full_messages).to eq(["Title has too many words"])
+  end
+
+  it "should not post with invalid description" do
+    title = "Morbi id lacus ac sem suscipit dapibus accumsan ac lorem"
+    description = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi id lacus ac sem suscipit dapibus accumsan ac lorem. Curabitur sollicitudin auctor velit, quis ultrices mi ornare id. Aliquam ac scelerisque dolor. Nullam nec pharetra lectus. Sed porta dolor ac suscipit ultricies. Fusce vulputate libero ac suscipit varius. Vivamus lorem mauris, maximus sed cursus eget, posuere non arcu. Proin ultrices, mi sit amet luctus mollis, nulla dui maximus mi, vitae elementum dolor urna at mauris. Duis sed mattis nibh. Cras mattis volutpat dictum. Duis nisi nisi, semper eu sem et, vehicula commodo leo. Mauris vulputate ligula viverra, semper mi at, elementum leo. Aliquam finibus lorem quam, et accumsan tellus faucibus eu. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Morbi faucibus risus placerat, rutrum libero in, aliquam diam. Nam eu nisl non nisi mattis accumsan. Curabitur sodales tellus quam. Donec cursus imperdiet ipsum, ac egestas sem. Integer lacus quam, venenatis eu pulvinar ac, vestibulum consectetur neque. Mauris aliquam ultricies dignissim. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec sed elit sed velit accumsan sodales et id purus. Proin sed quam a enim varius sodales. Maecenas vel lectus sem. Duis eu nulla faucibus, molestie justo vitae, laoreet nisi. Duis commodo eget odio."
+    talk = Talk.new(title: title, category: "category", description: description)
+    post :create, {params: talk.attributes}
+    expect(assigns(:talk).errors.full_messages).to eq(["Description has too many words"])
+  end
 end


### PR DESCRIPTION
Adds length validations to the Talk's title and description fields. Fixes #6.